### PR TITLE
Update mongodb to 3.6 in preparation for migration from mLab to Atlas

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
   },
   "homepage": "https://github.com/newamericafoundation/febp-backend#readme",
   "dependencies": {
-    "body-parser": "^1.16.1",
+    "body-parser": "^1.19.0",
     "cors": "^2.8.4",
-    "express": "^4.14.1",
+    "express": "^4.17.1",
     "helmet": "^3.9.0",
     "json2csv": "^3.7.3",
-    "mongodb": "^2.2.23",
+    "mongodb": "^3.6.0",
     "mongonaut": "^3.0.0",
     "path": "^0.12.7",
     "react": "^15.5.4"


### PR DESCRIPTION
See https://docs.mlab.com/how-to-migrate-sandbox-heroku-addons-to-atlas/ guide (prerequisites section) and the compatibility grid for the node driver here: https://docs.mongodb.com/drivers/node/compatibility